### PR TITLE
fix: footer spacing on case study pages

### DIFF
--- a/src/components/Projects/ProjectDetails.module.scss
+++ b/src/components/Projects/ProjectDetails.module.scss
@@ -6,6 +6,8 @@
   transform: translateY(40px);
   transition: all 0.6s ease;
   overflow-x: hidden;
+  padding-top: 100px;
+  padding-bottom: 100px;
 
   &.animate {
     opacity: 1;

--- a/src/styles/common.scss
+++ b/src/styles/common.scss
@@ -684,3 +684,7 @@ label {
         overflow: auto;
     }
 }
+
+.pageContent {
+    padding-bottom: 100px;
+}


### PR DESCRIPTION

FIxed the spacing bug between footer and data ,This was the before 
<img width="1875" height="913" alt="2026-06-15-113321_hyprshot" src="https://github.com/user-attachments/assets/97b13c26-b0f9-4871-aa2e-88d055f0896e" />
And this is the after
<img width="1880" height="903" alt="2026-06-15-113403_hyprshot" src="https://github.com/user-attachments/assets/ad871af9-569e-40fa-9737-5ffbf955c538" />

